### PR TITLE
ci(build-and-publish.jf): apt mirror selection option

### DIFF
--- a/ci/0-install-rocm.sh
+++ b/ci/0-install-rocm.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # MIT License
-# 
+#
 # Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -57,9 +57,10 @@ ROCM_VER_SHORT=$(echo $ROCM_VER | sed "s,\([0-9]\+\.[0-9]\+\)\.0,\1,g")
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VER_SHORT} focal main" | sudo tee /etc/apt/sources.list.d/rocm.list
 echo -e 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | sudo tee /etc/apt/preferences.d/rocm-pin-600
 sudo apt update
- 
+
 # install ROCm
 sudo amdgpu-install -y --usecase=rocm --rocmrelease=${ROCM_VER} --no-dkms
 sudo apt install -y rocm-llvm-dev${ROCM_VER} || true # required for ROCM_VER>=6.1.0
 
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib
+

--- a/ci/1-install-conda.sh
+++ b/ci/1-install-conda.sh
@@ -29,7 +29,7 @@ fi
 set -e
 set -o xtrace
 
-CONDA_DIR=${CONDA_DIR:~/miniconda3}
+CONDA_DIR=${CONDA_DIR:-~/miniconda3}
 mkdir -p ${CONDA_DIR}
 wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${CONDA_DIR}/miniconda.sh
 bash ${CONDA_DIR}/miniconda.sh -b -u -p ${CONDA_DIR}

--- a/ci/1-install-conda.sh
+++ b/ci/1-install-conda.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # MIT License
-# 
+#
 # Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,8 +29,10 @@ fi
 set -e
 set -o xtrace
 
-mkdir -p ~/miniconda3
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-rm -rf ~/miniconda3/miniconda.sh
-~/miniconda3/bin/conda init bash
+CONDA_DIR=${CONDA_DIR:~/miniconda3}
+mkdir -p ${CONDA_DIR}
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${CONDA_DIR}/miniconda.sh
+bash ${CONDA_DIR}/miniconda.sh -b -u -p ${CONDA_DIR}
+rm -rf ${CONDA_DIR}/miniconda.sh
+${CONDA_DIR}/bin/conda init bash
+

--- a/ci/2-create-conda-envs.sh
+++ b/ci/2-create-conda-envs.sh
@@ -35,4 +35,3 @@ for pyver in "38" "39" "310" "311";
 do
   conda env create -n py${pyver} -f ci/envs/py${pyver}.yml
 done
-

--- a/ci/2-create-conda-envs.sh
+++ b/ci/2-create-conda-envs.sh
@@ -29,7 +29,7 @@ fi
 set -e
 set -o xtrace
 
-CONDA_DIR=${CONDA_DIR:~/miniconda3}
+CONDA_DIR=${CONDA_DIR:-~/miniconda3}
 source ${CONDA_DIR}/etc/profile.d/conda.sh
 for pyver in "38" "39" "310" "311";
 do

--- a/ci/2-create-conda-envs.sh
+++ b/ci/2-create-conda-envs.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # MIT License
-# 
+#
 # Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -29,8 +29,10 @@ fi
 set -e
 set -o xtrace
 
-source ~/miniconda3/etc/profile.d/conda.sh
+CONDA_DIR=${CONDA_DIR:~/miniconda3}
+source ${CONDA_DIR}/etc/profile.d/conda.sh
 for pyver in "38" "39" "310" "311";
 do
   conda env create -n py${pyver} -f ci/envs/py${pyver}.yml
 done
+

--- a/ci/3a-build-and-test-for-single-cpython-version.sh
+++ b/ci/3a-build-and-test-for-single-cpython-version.sh
@@ -31,8 +31,10 @@ fi
 set -e
 set -o xtrace
 
-source ~/miniconda3/etc/profile.d/conda.sh
+CONDA_DIR=${CONDA_DIR:~/miniconda3}
+source ${CONDA_DIR}/etc/profile.d/conda.sh
 pyver=38
 conda activate py${pyver}
 ./build_pkg.sh --pre-clean --post-clean --run-tests -j ${NUM_JOBS:-16}
 conda deactivate
+

--- a/ci/3a-build-and-test-for-single-cpython-version.sh
+++ b/ci/3a-build-and-test-for-single-cpython-version.sh
@@ -37,4 +37,3 @@ pyver=38
 conda activate py${pyver}
 ./build_pkg.sh --pre-clean --post-clean --run-tests -j ${NUM_JOBS:-16}
 conda deactivate
-

--- a/ci/3a-build-and-test-for-single-cpython-version.sh
+++ b/ci/3a-build-and-test-for-single-cpython-version.sh
@@ -31,7 +31,7 @@ fi
 set -e
 set -o xtrace
 
-CONDA_DIR=${CONDA_DIR:~/miniconda3}
+CONDA_DIR=${CONDA_DIR:-~/miniconda3}
 source ${CONDA_DIR}/etc/profile.d/conda.sh
 pyver=38
 conda activate py${pyver}

--- a/ci/3b-build-and-test-for-multiple-cpython-versions.sh
+++ b/ci/3b-build-and-test-for-multiple-cpython-versions.sh
@@ -31,7 +31,7 @@ fi
 set -e
 set -o xtrace
 
-CONDA_DIR=${CONDA_DIR:~/miniconda3}
+CONDA_DIR=${CONDA_DIR:-~/miniconda3}
 source ${CONDA_DIR}/etc/profile.d/conda.sh
 for pyver in "38" "39" "310" "311";
 do

--- a/ci/3b-build-and-test-for-multiple-cpython-versions.sh
+++ b/ci/3b-build-and-test-for-multiple-cpython-versions.sh
@@ -31,7 +31,8 @@ fi
 set -e
 set -o xtrace
 
-source ~/miniconda3/etc/profile.d/conda.sh
+CONDA_DIR=${CONDA_DIR:~/miniconda3}
+source ${CONDA_DIR}/etc/profile.d/conda.sh
 for pyver in "38" "39" "310" "311";
 do
   conda activate py${pyver}
@@ -42,3 +43,4 @@ do
   fi
   conda deactivate
 done
+

--- a/ci/4-prepare-upload-binary.sh
+++ b/ci/4-prepare-upload-binary.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # MIT License
-# 
+#
 # Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,3 +39,4 @@ do
    mv $f ${f/linux/manylinux_2_17}
 done
 cd ..
+

--- a/ci/5-upload-binary.sh
+++ b/ci/5-upload-binary.sh
@@ -42,7 +42,7 @@ if [ -z ${BINARY_REPO_TOKEN+x} ]; then
   exit 1
 fi
 
-CONDA_DIR=${CONDA_DIR:~/miniconda3}
+CONDA_DIR=${CONDA_DIR:-~/miniconda3}
 source ${CONDA_DIR}/etc/profile.d/conda.sh
 pyver=38
 conda activate py${pyver}

--- a/ci/5-upload-binary.sh
+++ b/ci/5-upload-binary.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # MIT License
-# 
+#
 # Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -42,8 +42,10 @@ if [ -z ${BINARY_REPO_TOKEN+x} ]; then
   exit 1
 fi
 
-source ~/miniconda3/etc/profile.d/conda.sh
+CONDA_DIR=${CONDA_DIR:~/miniconda3}
+source ${CONDA_DIR}/etc/profile.d/conda.sh
 pyver=38
 conda activate py${pyver}
 python3 -m twine upload --repository ${BINARY_REPO} _upload/*.whl -u__token__ -p${BINARY_REPO_TOKEN}
 conda deactivate
+

--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -66,6 +66,13 @@ pipeline {
         )
         editableChoice(
             choices: [
+                'main',
+            ],
+            description: 'The branch where the ci scripts, docs and other files imported by `init.sh` are located.',
+            name: 'CI_BRANCH'
+        )
+        editableChoice(
+            choices: [
                 "mirror.math.ucdavis.edu",
                 "archive.ubuntu.com",
             ],

--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -35,6 +35,7 @@ pipeline {
     parameters {
         editableChoice(
             choices: [
+                '6.1.0',
                 '6.0.0',
                 '5.7.1',
                 '5.7.0',
@@ -63,6 +64,14 @@ pipeline {
             description: 'The branch name will be constructed as `${RELEASE_BRANCH_PREFIX}/rocm-rel-${ROCM_VER}`. `develop` is first to make it default.',
             name: 'RELEASE_BRANCH_PREFIX'
         )
+        editableChoice(
+            choices: [
+                "mirror.math.ucdavis.edu",
+                "archive.ubuntu.com",
+            ],
+            description: 'Use a different Ubuntu mirror; see https://launchpad.net/ubuntu/+archivemirrors. First is default.',
+            name: 'UBUNTU_APT_MIRROR'
+        )
     }
     stages {
         stage('clean-ws') {
@@ -72,8 +81,11 @@ pipeline {
         }
         stage('get-repo') {
             steps {
+                sh '''#!/usr/bin/env bash
+                sed -i "s,archive.ubuntu.com,${UBUNTU_APT_MIRROR},g" /etc/apt/sources.list
+                apt-get update && apt-get -y install git sudo
+                '''
                 git branch: 'main', credentialsId: 'ROCM_LLVM_PYTHON_DEV', url: 'https://github.com/ROCmSoftwarePlatform/rocm-llvm-python'
-                sh 'apt update && apt install -y git'
                 dir('.') {
                     withCredentials([
                         usernamePassword(credentialsId: 'ROCM_LLVM_PYTHON_DEV', passwordVariable: 'GITHUB_TOKEN', usernameVariable: 'GITHUB_USER'),

--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -29,6 +29,9 @@ pipeline {
             args '--device=/dev/kfd --device=/dev/dri --group-add=video --ipc=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
         }
     }
+    environment {
+        CONDA_DIR = '/opt/rocm'
+    }
     parameters {
         editableChoice(
             choices: [

--- a/ci/build-and-publish.jf
+++ b/ci/build-and-publish.jf
@@ -30,7 +30,7 @@ pipeline {
         }
     }
     environment {
-        CONDA_DIR = '/opt/rocm'
+        CONDA_DIR = '/opt/conda'
     }
     parameters {
         editableChoice(


### PR DESCRIPTION
## Testing changes

* This PR disables the `examples/1_Advanced/hiprtc_linking_with_llvm_ir.py` test with ROCm 6.1.0 as `hiprtcCompileProgram` does not work as expected with this release.

## CI changes

* Allows to configure the conda installation directory via the `CONDA_DIR` environment variable.
* Allows to select a different apt mirror if the default Ubuntu one is too slow.
* Add Rocm `6.1.0` choice. Note that we will ignore patch releases, e.g., `6.0.2`, for the foreseeable future unless there is a reason for regenerating the interfaces for this patch.

## Testing TODOs

* [x] Generate ROCm 6.1.0 release sources and test pypi packages with this branch.