### PR TITLE
fix(**/test_examples.*): init skipif condition operands in except too

### DIFF
--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -29,6 +29,8 @@ try:
     import hip
 except:
     have_matching_hip_python = False
+    have_compatible_gpu_target = False
+    hiprtc_cannot_produce_llvm_bitcode = False
 else:
     import rocm.llvm
     from hip import hip as hiprt


### PR DESCRIPTION
Variables need to be initialized in except case too, otherwise the `pytest.mark.skipif` conditions cannot be evaluated.