### PR TITLE
[FIX][6.4.0][main] Examples/tests: Use and test `amd_comgr_action_info_set_option_list`

### DIFF
--- a/_render_update_version.py
+++ b/_render_update_version.py
@@ -18,7 +18,7 @@ def git_branch_rev_count(branch):
 
 def git_current_branch():
     """Return the name of the current branch."""
-    return subprocess.check_output(["git","branch","--show-current"]).decode("utf-8").strip()
+    return subprocess.check_output(["git","rev-parse","--abbrev-ref", "HEAD"]).decode("utf-8").strip()
 
 def replace_version_placeholders(file_content: str) -> str:
     return file_content.format(

--- a/examples/1_Advanced/amd_comgr_hip_to_llvm_ir.py
+++ b/examples/1_Advanced/amd_comgr_hip_to_llvm_ir.py
@@ -26,7 +26,7 @@
 This time we use AMD COMGR infrastructure. This requires us to use the 
 `hiprtc_runtime.h` header file that HIPRTC is using internally.
 
-During the ROCm LLVM Python package preperation, we generate this header file
+During the ROCm LLVM Python package preparation process, we generate this header file
 and put it into the `rocm.amd_comgr.amd_comgr.ext.HIPRTC_RUNTIME_HEADER` 
 variable.
 """
@@ -69,7 +69,7 @@ class HipProgram:
             isa_name=f"amdgcn-amd-amdhsa--{arch}",
             hip_version_tuple=ROCM_VERSION_TUPLE,  # ! only same up to last entry
             logging=True,
-            extra_opts=" -D__HIPCC_RTC__ ",
+            extra_opts=["-D__HIPCC_RTC__"],
         )
         self.llvm_bc_or_ir_size = len(self.llvm_bc_or_ir)
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -41,7 +41,8 @@ else:
     hiprt.hipGetDeviceProperties(props, 0)
     gpugen = props.gcnArchName.decode("utf-8").split(":")[0]
     have_compatible_gpu_target = gpugen == "gfx90a"
-    hiprtc_cannot_produce_llvm_bitcode = rocm.llvm.ROCM_VERSION_TUPLE == (6,1,0)
+    hiprtc_cannot_produce_llvm_bitcode = rocm.llvm.ROCM_VERSION_TUPLE == (6, 1, 0)
+
 
 @pytest.mark.parametrize(
     "example",
@@ -52,10 +53,16 @@ else:
         "1_Advanced/amd_comgr_hip_to_llvm_ir.py",
         pytest.param(
             "1_Advanced/hiprtc_amd_comgr_get_jit_kernel_metadata.py",
-            marks=pytest.mark.skipif(
-                not have_matching_hip_python,
-                reason="requires that 'hip-python' is installed",
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    not have_matching_hip_python,
+                    reason="requires that 'hip-python' is installed",
+                ),
+                pytest.mark.xfail(
+                    hip.ROCM_VERSION_TUPLE < (6, 3, 2),
+                    reason="'amd_comgr.ext.compile_hip_to_bc' 'extra_opts' argument type change must be backported",
+                ),
+            ],
         ),
         pytest.param(
             "1_Advanced/hiprtc_hip_to_llvm_ir.py",
@@ -67,7 +74,8 @@ else:
         pytest.param(
             "1_Advanced/hiprtc_linking_with_llvm_ir.py",
             marks=pytest.mark.skipif(
-                not ( have_matching_hip_python or have_compatible_gpu_target ) or hiprtc_cannot_produce_llvm_bitcode,
+                not (have_matching_hip_python or have_compatible_gpu_target)
+                or hiprtc_cannot_produce_llvm_bitcode,
                 reason="requires that 'hip-python' is installed, compatible GPU target (==gfx90a) is present, and that HIPRTC can produce bitcode (ROCm != 6.1.0)",
             ),
         ),

--- a/tests/test_amd_comgr_pyext.py
+++ b/tests/test_amd_comgr_pyext.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2023-2024 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Demonstrates how to use the object-oriented APIs provided by module
+`rocm.amd_comgr.amd_comgr_pyext`.
+"""
+
+import rocm.amd_comgr.amd_comgr_pyext as comgrext
+
+
+def test_amd_comgr_set_option_list():
+    action = comgrext.Action("COMPILE_SOURCE_TO_BC")
+
+    def set_options():
+        action.set_options(["-O0", "-g"])
+        # argument should get out of scope
+
+    set_options()
+
+    assert action.get_num_options() == 2
+    assert action.get_option(0) == b"-O0"
+    assert action.get_option(1) == b"-g"


### PR DESCRIPTION
Routine `amd_comgr_action_info_set_options` will get removed in ROCm 6.4.0. It has been deprecated for a long time now (at least since ROCm 6.1.0). Therefore, this commit uses `amd_comgr_action_info_set_option_list` instead via the 
new interfaces provided by `amd_comgr_pyext.py`.

## TODOs

* [ ] Test via CI job.